### PR TITLE
Typo fixes accessibility & main activity

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -52,7 +52,7 @@
         android:layout_width="300dp"
         android:layout_height="67dp"
         android:checked="false"
-        android:text="@string/don_t_show_notifications_in_default_bar_not_reccomended"
+        android:text="@string/don_t_show_notifications_in_default_bar_not_recommended"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.494"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <string name="app_name">Hole-punch Display</string>
-    <string name="accessibility_service_description">Creates the hole-puch display.</string>
+    <string name="accessibility_service_description">Creates the hole-punch display.</string>
     <string name="accessibility_service_label">Hole-punch Display</string>
-    <string name="don_t_show_notifications_in_default_bar_not_reccomended">Don\'t show notifications in default bar. (Not reccomended)</string>
+    <string name="don_t_show_notifications_in_default_bar_not_recommended">Don\'t show notifications in default bar. (Not recommended)</string>
     <string name="grant_permissions">Grant Permissions</string>
     <string name="x_offset">X Offsets</string>
     <string name="y_offset">Y Offsets</string>
@@ -10,6 +10,6 @@
     <string name="donate">Donate</string>
     <string name="overlay_height_when_open">Overlay height when open</string>
     <string name="overlay_height_when_closed">Overlay height when closed</string>
-    <string name="overlay_width_increase_until_sides_dont_crop">Overlay widths (increase until sides dont crop)</string>
+    <string name="overlay_width_increase_until_sides_dont_crop">Overlay widths (increase until sides don\'t crop)</string>
     <string name="todo">TODO</string>
 </resources>


### PR DESCRIPTION
Typos in accessibility settings and in the main activity warning about hiding notifications in default bar and sizing guide:
- hole-_puch_ display -> hole-punch display
- Not _reccomended_ -> Not recommended
- sides _dont_ crop -> sides don't crop